### PR TITLE
Add saving of prefix to WeMod dir to avoid rebuilding

### DIFF
--- a/copier.py
+++ b/copier.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import os
+import shutil
+import pathlib
+import PySimpleGUI as sg
+
+
+def copy_folder_with_progress(source: str, dest: str, ignore=None, include_override=None) -> None:
+    if ignore is None:
+        ignore = set()
+
+    if include_override is None:
+        include_override = set()
+
+    def traverse_folders(path):
+        allf = []
+        directory = pathlib.Path(path)
+        for item in directory.rglob('*'): #sorted(, key=lambda x: str(x).count('/')):
+            if item.is_file():
+                allf.append(item)
+        return allf
+
+    def update_progress(copied, total):
+        """ Update the GUI with the current progress. """
+        percentage = int(100 * (copied / total)) if total > 0 else 0
+        text.update(f"{percentage}% ({copied}/{total})")
+        progress.update(percentage)
+        window.refresh()
+
+    sg.theme("systemdefault")
+
+    progress = sg.ProgressBar(100, orientation="h", s=(50, 10))
+    text = sg.Text("0%")
+    extra = sg.Text("Reading prefix directory, please wait..")
+    layout = [[extra] ,[progress], [text]]
+    window = sg.Window('Copying Prefix', layout, finalize=True)
+    window.refresh()
+
+    files = traverse_folders(source)
+
+    copy=[]
+    for f in files:
+        rfile = os.path.relpath(f, source)  # get file path relative to source
+        use = True  # by default, use the file
+
+        # Check if the file is in one of the dirs to ignore
+        for i in ignore:
+            if os.path.commonprefix([rfile, i]) == i:
+                use = False  # don't use the file if it's in an ignore directory
+                break  # break out of the ignore loop
+
+        # If the file is not in any ignored directory, check if it's in one of the dirs to include
+        if not use:
+            for i in include_override:
+                if os.path.commonprefix([rfile, i]) == i:
+                    use = True  # use the file if it's in an include_override directory
+                    break  # break out of the include_override loop
+        if use:
+            copy.append(rfile)
+
+    extra.update("Copying prefix, please be patient...")
+    window.refresh()
+
+    total_files = len(files)
+    copied_files = 0
+
+    for f in copy:
+        src_path = os.path.join(source, f)
+        dest_path = os.path.join(dest, f)
+        try:
+            os.makedirs(os.path.dirname(dest_path), exist_ok=True)
+            shutil.copy2(src_path, dest_path, follow_symlinks=False)
+        except:
+            pass
+        copied_files += 1
+        update_progress(copied_files, total_files)
+
+
+    window.close()

--- a/wemod
+++ b/wemod
@@ -108,7 +108,7 @@ def init(proton: str) -> None:
 
     from copier import copy_folder_with_progress
     ignore={'pfx/drive_c/users','pfx/dosdevices','pfx/drive_c/Program Files (x86)','pfx/drive_c/Program Files',
-            'pfx/drive_c/ProgramData','drive_c/openxr','pfx/drive_c/vrclient'}
+            'pfx/drive_c/ProgramData','drive_c/openxr','pfx/drive_c/vrclient','version','config_info'}
     include_override={'pfx/drive_c/users/steamuser/AppData/Roaming/WeMod','pfx/drive_c/ProgramData/Microsoft',
                       'pfx/drive_c/Program Files (x86)/Microsoft.NET','pfx/drive_c/Program Files (x86)/Windows NT',
                       'pfx/drive_c/Program Files (x86)/Common Files','pfx/drive_c/Program Files/Common Files',

--- a/wemod
+++ b/wemod
@@ -116,7 +116,7 @@ def init(proton: str) -> None:
       if response == "Yes":
         # Copy the closest version's prefix to the gameprefix
         log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
-        window = sg.Window("Copying the prefix. Please be patient...", layout, keep_on_top=True, finalize=True)
+        window = sg.Window("Copying prefix", layout, keep_on_top=True, finalize=True)
         window.refresh()
         copy_prefix_folder(closest_prefix_folder, BASE_STEAM_COMPAT)
         window.close()
@@ -125,7 +125,7 @@ def init(proton: str) -> None:
         log("User chose not to use an alternative Proton version.")
     elif closest_prefix_folder and cut_version and cut_version == cut_proton_version:
       log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
-      window = sg.Window("Copying the prefix. Please be patient...", layout, keep_on_top=True, finalize=True)
+      window = sg.Window("Copying prefix", layout, keep_on_top=True, finalize=True)
       window.refresh()
       copy_prefix_folder(closest_prefix_folder, BASE_STEAM_COMPAT)
       window.close()

--- a/wemod
+++ b/wemod
@@ -119,13 +119,13 @@ def init(proton: str) -> None:
       if response == "Yes":
         # Copy the closest version's prefix to the gameprefix
         log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
-        copy_folder_with_progress(src,dst,ignore,include_override)
+        copy_folder_with_progress(closest_prefix_folder,BASE_STEAM_COMPAT,ignore,include_override)
         log(f"Copied Proton version {closest_version_number} prefix to game prefix")
       else:
         log("User chose not to use an alternative Proton version.")
     elif closest_prefix_folder and cut_version and cut_version == cut_proton_version:
       log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
-      copy_folder_with_progress(src,dst,ignore,include_override)
+      copy_folder_with_progress(closest_prefix_folder,BASE_STEAM_COMPAT,ignore,include_override)
       log("Copied exact Proton version prefix to game prefix")
     else:
       log("No compatible Proton version found in the compatibility folder.")

--- a/wemod
+++ b/wemod
@@ -117,6 +117,7 @@ def init(proton: str) -> None:
         # Copy the closest version's prefix to the gameprefix
         log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
         window = sg.Window("Copying the prefix. Please be patient...", layout, keep_on_top=True, finalize=True)
+        window.refresh()
         copy_prefix_folder(closest_prefix_folder, BASE_STEAM_COMPAT)
         window.close()
         log(f"Copied Proton version {closest_version_number} prefix to game prefix")
@@ -125,6 +126,7 @@ def init(proton: str) -> None:
     elif closest_prefix_folder and cut_version and cut_version == cut_proton_version:
       log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
       window = sg.Window("Copying the prefix. Please be patient...", layout, keep_on_top=True, finalize=True)
+      window.refresh()
       copy_prefix_folder(closest_prefix_folder, BASE_STEAM_COMPAT)
       window.close()
       log("Copied exact Proton version prefix to game prefix")

--- a/wemod
+++ b/wemod
@@ -41,15 +41,15 @@ def parse_version(version_str = None):
       return None
   return None
 
-# Scan the steam compat folder for wemod installed prefixes
-def scanforversionfolder(current_proton_version: str):
-  def read_version(version_file): # read file
+def read_version(version_file): # read file
     try:
       with open(version_file, 'r') as file:
         return file.read().strip()
     except FileNotFoundError:
         return None
 
+# Scan the steam compat folder for wemod installed prefixes
+def scanforversionfolder(current_proton_version: str):
   # At default we dont know of any available version
   closest_version_folder = None
   closest_version_number = None
@@ -88,9 +88,9 @@ def init(proton: str) -> None:
   log(f"Looking for init file '{INIT_FILE}' in '{WINEPREFIX}'")
   if not os.path.exists(INIT_FILE):
     # Grab active proton version
-    result = subprocess.run([proton, "--version"], capture_output=True, text=True)
-    current_proton_version = result.stdout.strip() if result.returncode == 0 else None
-    cut_proton_version = parse_version(current_proton_version)
+    currend_proton_version = read_version(os.path.join(BASE_STEAM_COMPAT, "version"))
+    cut_proton_version = parse_version(currend_proton_version)
+
     log(f"Loking for compatible wine prefixes in '{STEAM_COMPAT_FOLDER}' with proton version '{cut_proton_version}'")
 
     # Get closest version that has wemod installed

--- a/wemod
+++ b/wemod
@@ -62,7 +62,7 @@ def scanforversionfolder(current_proton_version: str):
     folder_path = os.path.join(STEAM_COMPAT_FOLDER, folder)
     version_file = os.path.join(folder_path, "version")
     if os.path.isdir(folder_path) and os.path.exists(os.path.join(folder_path, "pfx", ".wemod_installer")):
-      folder_version = read_version(version_file)
+      folder_version = parse_version(read_version(version_file))
       if folder_version:
         # Compare version numbers
         try:

--- a/wemod
+++ b/wemod
@@ -91,7 +91,7 @@ def init(proton: str) -> None:
     result = subprocess.run([proton, "--version"], capture_output=True, text=True)
     current_proton_version = result.stdout.strip() if result.returncode == 0 else None
     cut_proton_version = parse_version(current_proton_version)
-    log(f"Loking for compatible wine prefixes in '{STEAM_COMPAT_FOLDER}' whit proton version '{cut_proton_version}'")
+    log(f"Loking for compatible wine prefixes in '{STEAM_COMPAT_FOLDER}' with proton version '{cut_proton_version}'")
 
     # Get closest version that has wemod installed
     closest_version, closest_prefix_folder = scanforversionfolder(cut_proton_version)

--- a/wemod
+++ b/wemod
@@ -31,14 +31,14 @@ def parse_version(version_str = None):
     # Split by '.' and limit to the first two components (major.minor)
     parts = clean_version.split('.')
     if len(parts) > 2:
-        parts = parts[:2]  # Keep only the first two parts
+      parts = parts[:2]  # Keep only the first two parts
 
     # Rejoin the parts and convert to a float
     version_number = '.'.join(parts)
     try:
-        return float(version_number)
+      return float(version_number)
     except ValueError:
-        return None
+      return None
   return None
 
 # Scan the steam compat folder for wemod installed prefixes

--- a/wemod
+++ b/wemod
@@ -13,13 +13,13 @@ SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 WEMOD_BAT = "C:\\\\windows\\\\system32\\\\start.exe Z:" + "\\\\".join(SCRIPT_PATH.split("/")) + "\\\\wemod.bat"
 BASE_STEAM_COMPAT = os.getenv("STEAM_COMPAT_DATA_PATH")
 WINEPREFIX = os.path.join(BASE_STEAM_COMPAT, "pfx")
-STEAM_COMPAT_FOLDER = os.path.abspath(os.path.join(WINEPREFIX, os.pardir))
+STEAM_COMPAT_FOLDER = os.path.abspath(os.path.join(os.path.abspath(os.path.join(WINEPREFIX, os.pardir)), os.pardir))
 WINETRICKS = os.path.join(SCRIPT_PATH, "winetricks")
 INIT_FILE = os.path.join(WINEPREFIX, ".wemod_installer")
 
 def parse_version(version_str = None):
   # Replace '-' with '.' and ',' with '.'
-  if version_str:
+  if version_str and isinstance(version_str, str):
     dot_version = version_str.replace("-", ".").replace(",", ".")
 
     # Remove the Everything except for numbers and dots
@@ -39,6 +39,8 @@ def parse_version(version_str = None):
       return float(version_number)
     except ValueError:
       return None
+  elif isinstance(version_str, int) or isinstance(version_str, float):
+    return float(version_str)
   return None
 
 def read_version(version_file): # read file
@@ -49,7 +51,7 @@ def read_version(version_file): # read file
         return None
 
 # Scan the steam compat folder for wemod installed prefixes
-def scanforversionfolder(current_proton_version: str):
+def scanfolderforversions(current_proton_version: str):
   # At default we dont know of any available version
   closest_version_folder = None
   closest_version_number = None
@@ -84,17 +86,17 @@ def init(proton: str) -> None:
     os.makedirs(os.getenv("STEAM_COMPAT_DATA_PATH"), exist_ok=True)
     os.makedirs(WINEPREFIX, exist_ok=True)
 
-  # If wemod is not installed try to copy a working prefix to the currend one
+  # If wemod is not installed try to copy a working prefix to the current one
   log(f"Looking for init file '{INIT_FILE}' in '{WINEPREFIX}'")
   if not os.path.exists(INIT_FILE):
     # Grab active proton version
-    currend_proton_version = read_version(os.path.join(BASE_STEAM_COMPAT, "version"))
-    cut_proton_version = parse_version(currend_proton_version)
+    current_proton_version = read_version(os.path.join(BASE_STEAM_COMPAT, "version"))
+    cut_proton_version = parse_version(current_proton_version)
 
     log(f"Loking for compatible wine prefixes in '{STEAM_COMPAT_FOLDER}' with proton version '{cut_proton_version}'")
 
     # Get closest version that has wemod installed
-    closest_version, closest_prefix_folder = scanforversionfolder(cut_proton_version)
+    closest_version, closest_prefix_folder = scanfolderforversions(cut_proton_version)
     cut_version = parse_version(closest_version)
     log(f"Found was '{cut_version}' on '{closest_prefix_folder}'")
 
@@ -102,11 +104,13 @@ def init(proton: str) -> None:
       response = sg.popup_yes_no(f"This Proton version is not installed. Would you like to attempt to use the closest installed version ({closest_version_number}) which may result in some issues?")
       if response == "Yes":
         # Copy the closest version's prefix to the gameprefix
+        log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
         shutil.copytree(closest_prefix_folder, BASE_STEAM_COMPAT, dirs_exist_ok=True)
         log(f"Copied Proton version {closest_version_number} prefix to game prefix")
       else:
         log("User chose not to use an alternative Proton version.")
     elif closest_prefix_folder and cut_version and cut_version == cut_proton_version:
+      log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
       shutil.copytree(closest_prefix_folder, BASE_STEAM_COMPAT, dirs_exist_ok=True)
       log("Copied exact Proton version prefix to game prefix")
     else:

--- a/wemod
+++ b/wemod
@@ -19,10 +19,14 @@ PREFIX_IN_WEMOD_FOLDER = os.path.join(SCRIPT_PATH, "proton")
 def init(proton: str) -> None:
   import PySimpleGUI as sg
 
-  # Create wineprefix directory if it doesn't exist
+  # Create wemod wineprefix directory if it doesn't exist
   if not os.path.isdir(WINEPREFIX):
     os.makedirs(os.getenv("STEAM_COMPAT_DATA_PATH"), exist_ok=True)
     os.makedirs(WINEPREFIX, exist_ok=True)
+
+  # Create wineprefix directory if it doesn't exist
+  if not os.path.isdir(PREFIX_IN_WEMOD_FOLDER):
+    os.makedirs(PREFIX_IN_WEMOD_FOLDER, exist_ok=True)
 
   # Check for the initialization file in the wineprefix
   log("Looking for init file '{}' in '{}'".format(INIT_FILE, WINEPREFIX))

--- a/wemod
+++ b/wemod
@@ -19,12 +19,12 @@ PREFIX_IN_WEMOD_FOLDER = os.path.join(SCRIPT_PATH, "proton")
 def init(proton: str) -> None:
   import PySimpleGUI as sg
 
-  # Create wemod wineprefix directory if it doesn't exist
+  # Create wineprefix directory if it doesn't exist
   if not os.path.isdir(WINEPREFIX):
     os.makedirs(os.getenv("STEAM_COMPAT_DATA_PATH"), exist_ok=True)
     os.makedirs(WINEPREFIX, exist_ok=True)
 
-  # Create wineprefix directory if it doesn't exist
+  # Create  wemod wineprefix directory if it doesn't exist
   if not os.path.isdir(PREFIX_IN_WEMOD_FOLDER):
     os.makedirs(PREFIX_IN_WEMOD_FOLDER, exist_ok=True)
 

--- a/wemod
+++ b/wemod
@@ -115,6 +115,7 @@ def init(proton: str) -> None:
                       'pfx/drive_c/Program Files/Common Files','pfx/drive_c/Program Files/Windows NT'}
 
     if closest_prefix_folder and cut_version and cut_version != cut_proton_version:
+      import PySimpleGUI as sg
       response = sg.popup_yes_no(f"This Proton version is not installed. Would you like to attempt to use the closest installed version ({closest_version_number}) which may result in some issues?")
       if response == "Yes":
         # Copy the closest version's prefix to the gameprefix

--- a/wemod
+++ b/wemod
@@ -106,29 +106,26 @@ def init(proton: str) -> None:
     cut_version = parse_version(closest_version)
     log(f"Found was '{cut_version}' on '{closest_prefix_folder}'")
 
-    import PySimpleGUI as sg
-    sg.theme("systemdefault")
-    text = sg.Text("Copying the prefix. Please be patient...")
-    layout = [ [text] ]
+    from copier import copy_folder_with_progress
+    ignore={'pfx/drive_c/users','pfx/dosdevices','pfx/drive_c/Program Files (x86)','pfx/drive_c/Program Files',
+            'pfx/drive_c/ProgramData','drive_c/openxr','pfx/drive_c/vrclient'}
+    include_override={'pfx/drive_c/users/steamuser/AppData/Roaming/WeMod','pfx/drive_c/ProgramData/Microsoft',
+                      'pfx/drive_c/Program Files (x86)/Microsoft.NET','pfx/drive_c/Program Files (x86)/Windows NT',
+                      'pfx/drive_c/Program Files (x86)/Common Files','pfx/drive_c/Program Files/Common Files',
+                      'pfx/drive_c/Program Files/Common Files','pfx/drive_c/Program Files/Windows NT'}
 
     if closest_prefix_folder and cut_version and cut_version != cut_proton_version:
       response = sg.popup_yes_no(f"This Proton version is not installed. Would you like to attempt to use the closest installed version ({closest_version_number}) which may result in some issues?")
       if response == "Yes":
         # Copy the closest version's prefix to the gameprefix
         log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
-        window = sg.Window("Copying prefix", layout, keep_on_top=True, finalize=True)
-        window.refresh()
-        copy_prefix_folder(closest_prefix_folder, BASE_STEAM_COMPAT)
-        window.close()
+        copy_folder_with_progress(src,dst,ignore,include_override)
         log(f"Copied Proton version {closest_version_number} prefix to game prefix")
       else:
         log("User chose not to use an alternative Proton version.")
     elif closest_prefix_folder and cut_version and cut_version == cut_proton_version:
       log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
-      window = sg.Window("Copying prefix", layout, keep_on_top=True, finalize=True)
-      window.refresh()
-      copy_prefix_folder(closest_prefix_folder, BASE_STEAM_COMPAT)
-      window.close()
+      copy_folder_with_progress(src,dst,ignore,include_override)
       log("Copied exact Proton version prefix to game prefix")
     else:
       log("No compatible Proton version found in the compatibility folder.")

--- a/wemod
+++ b/wemod
@@ -76,15 +76,6 @@ def scanfolderforversions(current_proton_version: str):
           continue
   return closest_version_number, closest_version_folder
 
-
-def copy_prefix_folder(src, dst):
-  import distutils.dir_util
-  try:
-    distutils.dir_util.copy_tree(src, dst)
-    return True
-  except Exception as e:
-    return False
-
 # Initialize the environment
 def init(proton: str) -> None:
   # Create wineprefix directory if it doesn't exist

--- a/wemod
+++ b/wemod
@@ -13,7 +13,7 @@ SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 WEMOD_BAT = "C:\\\\windows\\\\system32\\\\start.exe Z:" + "\\\\".join(SCRIPT_PATH.split("/")) + "\\\\wemod.bat"
 BASE_STEAM_COMPAT = os.getenv("STEAM_COMPAT_DATA_PATH")
 WINEPREFIX = os.path.join(BASE_STEAM_COMPAT, "pfx")
-STEAM_COMPAT_FOLDER = os.path.dirname(WINEPREFIX)
+STEAM_COMPAT_FOLDER = os.path.abspath(os.path.join(WINEPREFIX, os.pardir))
 WINETRICKS = os.path.join(SCRIPT_PATH, "winetricks")
 INIT_FILE = os.path.join(WINEPREFIX, ".wemod_installer")
 

--- a/wemod
+++ b/wemod
@@ -107,7 +107,7 @@ def init(proton: str) -> None:
 
     if closest_prefix_folder and cut_version and cut_version != cut_proton_version:
       import PySimpleGUI as sg
-      response = sg.popup_yes_no(f"This Proton version is not installed. Would you like to attempt to use the closest installed version ({cut_version}) which may result in some issues?")
+      response = sg.popup_yes_no(f"The Proton version {cut_proton_version} is not installed. Would you like to attempt to use the closest installed version {cut_version} which may result in some issues?")
       if response == "Yes":
         # Copy the closest version's prefix to the gameprefix
         log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')

--- a/wemod
+++ b/wemod
@@ -116,12 +116,12 @@ def init(proton: str) -> None:
 
     if closest_prefix_folder and cut_version and cut_version != cut_proton_version:
       import PySimpleGUI as sg
-      response = sg.popup_yes_no(f"This Proton version is not installed. Would you like to attempt to use the closest installed version ({closest_version_number}) which may result in some issues?")
+      response = sg.popup_yes_no(f"This Proton version is not installed. Would you like to attempt to use the closest installed version ({cut_version}) which may result in some issues?")
       if response == "Yes":
         # Copy the closest version's prefix to the gameprefix
         log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
         copy_folder_with_progress(closest_prefix_folder,BASE_STEAM_COMPAT,ignore,include_override)
-        log(f"Copied Proton version {closest_version_number} prefix to game prefix")
+        log(f"Copied Proton version {cut_version} prefix to game prefix")
       else:
         log("User chose not to use an alternative Proton version.")
     elif closest_prefix_folder and cut_version and cut_version == cut_proton_version:

--- a/wemod
+++ b/wemod
@@ -13,6 +13,7 @@ WEMOD_BAT = "C:\\\\windows\\\\system32\\\\start.exe Z:" + "\\\\".join(SCRIPT_PAT
 WINEPREFIX = os.path.join(os.getenv("STEAM_COMPAT_DATA_PATH"), "pfx")
 WINETRICKS = os.path.join(SCRIPT_PATH, "winetricks")
 INIT_FILE = os.path.join(WINEPREFIX, ".wemod_installer")
+PREFIX_IN_WEMOD_FOLDER = os.path.join(SCRIPT_PATH, "proton")
 
 # Initialize the environment
 def init(proton: str) -> None:
@@ -25,6 +26,20 @@ def init(proton: str) -> None:
 
   # Check for the initialization file in the wineprefix
   log("Looking for init file '{}' in '{}'".format(INIT_FILE, WINEPREFIX))
+  gameprefix_ready = os.path.exists(INIT_FILE)
+
+   # Check for ready prefix in wemod folder
+  ready_prefix_in_wemod_folder = os.path.exists(os.path.join(PREFIX_IN_WEMOD_FOLDER, ".wemod_installer"))
+
+   # Decide the action based on prefix status
+  if gameprefix_ready and not ready_prefix_in_wemod_folder:
+    shutil.copytree(WINEPREFIX, PREFIX_IN_WEMOD_FOLDER, dirs_exist_ok=True)
+    log("Copied game prefix to WEMOD folder")
+  elif not gameprefix_ready and ready_prefix_in_wemod_folder:
+    shutil.copytree(PREFIX_IN_WEMOD_FOLDER, WINEPREFIX, dirs_exist_ok=True)
+    log("Copied prefix in WEMOD folder to game prefix")
+
+  # Check once more for the initialization file in the wineprefix
   if os.path.exists(INIT_FILE):
     log("Found init file. Continuing launch...")
     return

--- a/wemod
+++ b/wemod
@@ -3,6 +3,7 @@
 import shutil
 import sys
 import os
+import re
 import subprocess
 from util import cache, exit_with_message, get_dotnet48, popup_download, wine, winetricks, log, popup_execute, pip, popup_options, deref
 from setup import main
@@ -10,10 +11,67 @@ from setup import main
 # Define paths and constants
 SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 WEMOD_BAT = "C:\\\\windows\\\\system32\\\\start.exe Z:" + "\\\\".join(SCRIPT_PATH.split("/")) + "\\\\wemod.bat"
-WINEPREFIX = os.path.join(os.getenv("STEAM_COMPAT_DATA_PATH"), "pfx")
+BASE_STEAM_COMPAT = os.getenv("STEAM_COMPAT_DATA_PATH")
+WINEPREFIX = os.path.join(BASE_STEAM_COMPAT, "pfx")
+STEAM_COMPAT_FOLDER = os.path.dirname(WINEPREFIX)
 WINETRICKS = os.path.join(SCRIPT_PATH, "winetricks")
 INIT_FILE = os.path.join(WINEPREFIX, ".wemod_installer")
-PREFIX_IN_WEMOD_FOLDER = os.path.join(SCRIPT_PATH, "proton")
+
+def parse_version(version_str):
+    # Replace '-' with '.' and ',' with '.'
+    dot_version = version_str.replace("-", ".").replace(",", ".")
+
+    # Remove the Everything except for numbers and dots
+    reduced_version = re.sub(r"[^\d.]", "", dot_version)
+
+    # Remove . from front and back
+    clean_version = reduced_version.strip(".")
+
+    # Split by '.' and limit to the first two components (major.minor)
+    parts = clean_version.split('.')
+    if len(parts) > 2:
+        parts = parts[:2]  # Keep only the first two parts
+
+    # Rejoin the parts and convert to a float
+    version_number = '.'.join(parts)
+    try:
+        return float(version_number)
+    except ValueError:
+        return None
+
+# Scan the steam compat folder for wemod installed prefixes
+def scanforversionfolder(current_proton_version: str):
+  def read_version(version_file): # read file
+    try:
+      with open(version_file, 'r') as file:
+        return file.read().strip()
+    except FileNotFoundError:
+        return None
+
+  # At default we dont know of any available version
+  closest_version_folder = None
+  closest_version_number = None
+  # And we have infinite div between them
+  version_diff = float('inf')
+
+  # For all folders in steam compat
+  for folder in os.listdir(STEAM_COMPAT_FOLDER):
+    # Get the version file, folder path and check if wemod is installed
+    folder_path = os.path.join(STEAM_COMPAT_FOLDER, folder)
+    version_file = os.path.join(folder_path, "version")
+    if os.path.isdir(folder_path) and os.path.exists(os.path.join(folder_path, "pfx", ".wemod_installer")):
+      folder_version = read_version(version_file)
+      if folder_version:
+        # Compare version numbers
+        try:
+          if abs(float(folder_version) - float(current_proton_version)) < version_diff:
+            version_diff = abs(float(folder_version) - float(current_proton_version))
+            closest_version_folder = folder_path
+            closest_version_number = folder_version
+        except ValueError:
+          continue
+  return closest_version_number, closest_version_folder
+
 
 # Initialize the environment
 def init(proton: str) -> None:
@@ -24,26 +82,36 @@ def init(proton: str) -> None:
     os.makedirs(os.getenv("STEAM_COMPAT_DATA_PATH"), exist_ok=True)
     os.makedirs(WINEPREFIX, exist_ok=True)
 
-  # Create  wemod wineprefix directory if it doesn't exist
-  if not os.path.isdir(PREFIX_IN_WEMOD_FOLDER):
-    os.makedirs(PREFIX_IN_WEMOD_FOLDER, exist_ok=True)
+  # If wemod is not installed try to copy a working prefix to the currend one
+  log(f"Looking for init file '{INIT_FILE}' in '{WINEPREFIX}'")
+  if not os.path.exists(INIT_FILE):
+    # Grab active proton version
+    result = subprocess.run([proton, "--version"], capture_output=True, text=True)
+    current_proton_version = result.stdout.strip() if result.returncode == 0 else None
+    cut_proton_version = parse_version(current_proton_version)
+    log(f"Loking for compatible wine prefixes in '{STEAM_COMPAT_FOLDER}' whit proton version '{cut_proton_version}'")
+
+    # Get closest version that has wemod installed
+    closest_version, closest_prefix_folder = scanforversionfolder(cut_proton_version)
+    cut_version = parse_version(closest_version)
+    log(f"Found was '{cut_version}' on '{closest_prefix_folder}'")
+
+    if closest_prefix_folder and cut_version and cut_version != cut_proton_version:
+      response = sg.popup_yes_no(f"This Proton version is not installed. Would you like to attempt to use the closest installed version ({closest_version_number}) which may result in some issues?")
+      if response == "Yes":
+        # Copy the closest version's prefix to the gameprefix
+        shutil.copytree(closest_prefix_folder, BASE_STEAM_COMPAT, dirs_exist_ok=True)
+        log(f"Copied Proton version {closest_version_number} prefix to game prefix")
+      else:
+        log("User chose not to use an alternative Proton version.")
+    elif closest_prefix_folder and cut_version and cut_version == cut_proton_version:
+      shutil.copytree(closest_prefix_folder, BASE_STEAM_COMPAT, dirs_exist_ok=True)
+      log("Copied exact Proton version prefix to game prefix")
+    else:
+      log("No compatible Proton version found in the compatibility folder.")
 
   # Check for the initialization file in the wineprefix
-  log("Looking for init file '{}' in '{}'".format(INIT_FILE, WINEPREFIX))
-  gameprefix_ready = os.path.exists(INIT_FILE)
-
-   # Check for ready prefix in wemod folder
-  ready_prefix_in_wemod_folder = os.path.exists(os.path.join(PREFIX_IN_WEMOD_FOLDER, ".wemod_installer"))
-
-   # Decide the action based on prefix status
-  if gameprefix_ready and not ready_prefix_in_wemod_folder:
-    shutil.copytree(WINEPREFIX, PREFIX_IN_WEMOD_FOLDER, dirs_exist_ok=True)
-    log("Copied game prefix to WEMOD folder")
-  elif not gameprefix_ready and ready_prefix_in_wemod_folder:
-    shutil.copytree(PREFIX_IN_WEMOD_FOLDER, WINEPREFIX, dirs_exist_ok=True)
-    log("Copied prefix in WEMOD folder to game prefix")
-
-  # Check once more for the initialization file in the wineprefix
+  log(f"Looking once more for the init file")
   if os.path.exists(INIT_FILE):
     log("Found init file. Continuing launch...")
     return

--- a/wemod
+++ b/wemod
@@ -77,10 +77,16 @@ def scanfolderforversions(current_proton_version: str):
   return closest_version_number, closest_version_folder
 
 
+def copy_prefix_folder(src, dst):
+  import distutils.dir_util
+  try:
+    distutils.dir_util.copy_tree(src, dst)
+    return True
+  except Exception as e:
+    return False
+
 # Initialize the environment
 def init(proton: str) -> None:
-  import PySimpleGUI as sg
-
   # Create wineprefix directory if it doesn't exist
   if not os.path.isdir(WINEPREFIX):
     os.makedirs(os.getenv("STEAM_COMPAT_DATA_PATH"), exist_ok=True)
@@ -100,18 +106,27 @@ def init(proton: str) -> None:
     cut_version = parse_version(closest_version)
     log(f"Found was '{cut_version}' on '{closest_prefix_folder}'")
 
+    import PySimpleGUI as sg
+    sg.theme("systemdefault")
+    text = sg.Text("Copying the prefix. Please be patient...")
+    layout = [ [text] ]
+
     if closest_prefix_folder and cut_version and cut_version != cut_proton_version:
       response = sg.popup_yes_no(f"This Proton version is not installed. Would you like to attempt to use the closest installed version ({closest_version_number}) which may result in some issues?")
       if response == "Yes":
         # Copy the closest version's prefix to the gameprefix
         log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
-        shutil.copytree(closest_prefix_folder, BASE_STEAM_COMPAT, dirs_exist_ok=True)
+        window = sg.Window("Copying the prefix. Please be patient...", layout, keep_on_top=True, finalize=True)
+        copy_prefix_folder(closest_prefix_folder, BASE_STEAM_COMPAT)
+        window.close()
         log(f"Copied Proton version {closest_version_number} prefix to game prefix")
       else:
         log("User chose not to use an alternative Proton version.")
     elif closest_prefix_folder and cut_version and cut_version == cut_proton_version:
       log(f'Copying {closest_prefix_folder} to {BASE_STEAM_COMPAT}')
-      shutil.copytree(closest_prefix_folder, BASE_STEAM_COMPAT, dirs_exist_ok=True)
+      window = sg.Window("Copying the prefix. Please be patient...", layout, keep_on_top=True, finalize=True)
+      copy_prefix_folder(closest_prefix_folder, BASE_STEAM_COMPAT)
+      window.close()
       log("Copied exact Proton version prefix to game prefix")
     else:
       log("No compatible Proton version found in the compatibility folder.")

--- a/wemod
+++ b/wemod
@@ -17,8 +17,9 @@ STEAM_COMPAT_FOLDER = os.path.dirname(WINEPREFIX)
 WINETRICKS = os.path.join(SCRIPT_PATH, "winetricks")
 INIT_FILE = os.path.join(WINEPREFIX, ".wemod_installer")
 
-def parse_version(version_str):
-    # Replace '-' with '.' and ',' with '.'
+def parse_version(version_str = None):
+  # Replace '-' with '.' and ',' with '.'
+  if version_str:
     dot_version = version_str.replace("-", ".").replace(",", ".")
 
     # Remove the Everything except for numbers and dots
@@ -38,6 +39,7 @@ def parse_version(version_str):
         return float(version_number)
     except ValueError:
         return None
+  return None
 
 # Scan the steam compat folder for wemod installed prefixes
 def scanforversionfolder(current_proton_version: str):


### PR DESCRIPTION
Added a command to copy the game prefix to the wemod dir and back to make new games use the ready wine prefix, that will avoid rebuilding of the wine prefix
This is what I tried to asked for in [Issue 31](https://github.com/DaniAsh551/wemod-launcher/issues/31).
Would be nice if you could add it.