### PR TITLE
Check twice for unreliable batch

### DIFF
--- a/util.py
+++ b/util.py
@@ -105,12 +105,22 @@ def pip(command: str,venv_path=None) -> int:
 
 # Function for logging messages
 def log(message: str):
-    if "WEMOD_LOG" in os.environ:
-        message = str(message)
-        if message and message[-1] != "\n":
-            message += "\n"
-        with open(os.getenv("WEMOD_LOG"), "a") as f:
-            f.write(message)
+    wemodlog = os.getenv('WEMOD_LOG')
+    if wemodlog != "":
+        try:
+            wemodlog = os.path.realpath(wemodlog)
+            os.makedirs(os.path.dirname(wemodlog), exist_ok = True)
+        except:
+            wemodlog = os.path.realpath(os.path.join(SCRIPT_PATH,"wemod.log"))
+            os.environ['WEMOD_LOG'] = wemodlog
+            log(f"WEMOD_LOG path was not given or invalid using path '{wemodlog}'\nIf you don't want to generate a logfile use WEMOD_LOG=''")
+            log(message)
+        else:
+            message = str(message)
+            if message and message[-1] != "\n":
+                message += "\n"
+            with open(wemodlog, "a") as f:
+                f.write(message)
 
 # Function to display a popup with options using FreeSimpleGUI
 def popup_options(title: str, message: str, options: list[str]) -> str:

--- a/wemod.bat
+++ b/wemod.bat
@@ -33,6 +33,10 @@ for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist /FI "IMAGENAME eq %w
 if not errorlevel 0 (
     goto wemod
 )
+if not defined wemodPID (
+    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist /FI "IMAGENAME eq %wemodname%"') do set wemodPID=%%b
+)
+
 
 REM Start the custom command and get its PID
 echo Running game %1.
@@ -52,15 +56,24 @@ for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "IMAGENAME e
 if not errorlevel 0 (
     goto game
 )
+if not defined commandPID (
+    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "IMAGENAME eq %~n1%~x1" /NH') do set commandPID=%%b
+)
 :loop
 set runningPID=
 for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH') do set runningPID=%%b
 if not errorlevel 0 (
     goto loop
 )
+@ping localhost -n 1 > NUL
+if not defined runningPID (
+    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH') do set runningPID=%%b
+    if not errorlevel 0 (
+        goto loop
+    )
+)
 
 if defined runningPID (
-    @ping localhost -n 1 > NUL
     if %counter% LSS 50 (
         set /A counter=%counter%+1
     )
@@ -76,9 +89,7 @@ if defined wemodPID (
         echo.
     )
     C:/windows/system32/taskkill.exe /PID %wemodPID% /F
-    if not errorlevel 0 (
-        C:/windows/system32/taskkill.exe /PID %wemodPID% /F
-    )
+    C:/windows/system32/taskkill.exe /PID %wemodPID% /F
 )
 echo.
 echo Killed %wemodname% over pid %wemodPID%

--- a/wemod.bat
+++ b/wemod.bat
@@ -65,7 +65,6 @@ for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %com
 if not errorlevel 0 (
     goto loop
 )
-@ping localhost -n 1 > NUL
 if not defined runningPID (
     for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH') do set runningPID=%%b
     if not errorlevel 0 (
@@ -74,6 +73,7 @@ if not defined runningPID (
 )
 
 if defined runningPID (
+    @ping localhost -n 1 > NUL
     if %counter% LSS 50 (
         set /A counter=%counter%+1
     )

--- a/wemod.bat
+++ b/wemod.bat
@@ -29,7 +29,7 @@ start "" %wemodpath%
 
 :wemod
 set wemodPID=
-for /F "TOKENS=1,2,*" %%a in ('tasklist /FI "IMAGENAME eq %wemodname%"') do set wemodPID=%%b
+for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist /FI "IMAGENAME eq %wemodname%"') do set wemodPID=%%b
 if not errorlevel 0 (
     goto wemod
 )
@@ -48,13 +48,13 @@ REM Couter to check if the game was detected correctly
 set /A counter=0
 
 :game
-for /F "TOKENS=1,2,*" %%a in ('tasklist /FI "IMAGENAME eq %~n1%~x1" /NH') do set commandPID=%%b
+for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "IMAGENAME eq %~n1%~x1" /NH') do set commandPID=%%b
 if not errorlevel 0 (
     goto game
 )
 :loop
 set runningPID=
-for /F "TOKENS=1,2,*" %%a in ('tasklist /FI "PID eq %commandPID%" /NH') do set runningPID=%%b
+for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH') do set runningPID=%%b
 if not errorlevel 0 (
     goto loop
 )
@@ -73,14 +73,15 @@ if defined wemodPID (
         echo.
         echo Game was probably not detected correctly, press a key to exit WeMod
         pause
+        echo.
     )
-    taskkill /PID %wemodPID% /F
+    C:/windows/system32/taskkill.exe /PID %wemodPID% /F
     if not errorlevel 0 (
-        taskkill /PID %wemodPID% /F
+        C:/windows/system32/taskkill.exe /PID %wemodPID% /F
     )
 )
 echo.
-echo Killed %wemodPID%
+echo Killed %wemodname% over pid %wemodPID%
 echo.
 echo Done, closing in 5 seconds
 @ping localhost -n 5 > NUL


### PR DESCRIPTION
Since the wine batch interface is unreliable,
we need to check twice to make sure the answer is correct.
Down there is a example screenshot of the problem,
also these commands failed after 2 minutes of runtime and later, so its super random.
![Screenshot_20240521_220626](https://github.com/DaniAsh551/wemod-launcher/assets/40715852/ab33dbf5-a9c8-4f40-a175-12e1265c676e)
Also i added a default log location.
If you don't want to generate a log file you will have to WEMOD_LOG=''.
Otherwise it will generate a log file at the default location {SCRIPT_DIR}/wemod.log.
