### PR TITLE
Remove top wait

### DIFF
--- a/wemod.bat
+++ b/wemod.bat
@@ -15,10 +15,6 @@ echo "%cd%"
 echo.
 echo command:
 echo %*
-echo.
-
-echo Waiting for 5 seconds to continue.
-@ping localhost -n 5 > NUL
 
 echo.
 echo.


### PR DESCRIPTION
The 5 second wait at the top can be removed since the cmd stays open anyway