### PR TITLE
Pull config update (v1.001)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ wemod_bin/
 wemod_data/
 wemod_venv/
 __pycache__/
+wemod.conf
 wemod.log
 winetricks
 pip.pyz

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,7 @@
 ![image](https://github.com/DaniAsh551/wemod-launcher/assets/90400991/dbb4bfce-2f29-45c1-a71b-2adfa8bf370e)
+- 22/5/2024 **|** A config was added to set/see repo user, repo name, venv path, log path,  
+  a overwrite for the steam compat path, script name and script version.
+- 21/5/2024 **|** Added code to the bat file so that wemod gets killed when the game closes.
 - 18/5/2024 **|** Replaced PySimpleGUI with FreeSimpleGUI so a license is no longer needed.
 - 18/5/2024 **|** Changed pip to use a venv to no longer be able to break packages.
 - 16/5/2024 **|** Added code to make prefix downloading work once more.

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,10 @@ I have tested this only on a handful of games,
 and you are welcome to report your findings/suggestions.
 
 ## Changes
+The most recent changes are at the top, check the [changelog](changelog.md) for more info.
+- Added simple config file for repo user, repo name, venv path, log path,  
+  a overwrite for the steam compat path, script name and script version.
+- Added code to the bat file so that wemod gets killed when the game closes.
 - Replaced PySimpleGUI with FreeSimpleGUI so a lisence is no longer needed.
 - Changed pip to use a venv so it can no longer break system packages.
 - Added code to make prefix downloading work once more.
@@ -38,7 +42,7 @@ and you are welcome to report your findings/suggestions.
   Thanks to Reddit user /u/pickworthi for finding it out.
 
 ## Guide
-<div><img src="https://cdn.discordapp.com/emojis/761419274945953842.webp?size=20&quality=lossless" alt="WeModApp"/>&nbsp;<b>If you prefer a video tutorial, one is now available:</b> <a href="https://youtu.be/5UlVCZvIl1E"> WeMod-launcher Setup Tutorial by Marvin1099</a></div>
+<div><img src="https://cdn.discordapp.com/emojis/761419274945953842.webp?size=20&quality=lossless" alt="WeModApp"/>&nbsp;<b>If you prefer a video tutorial, one is now available:</b><br><a href="https://youtu.be/5UlVCZvIl1E"> WeMod-launcher Setup Tutorial by Marvin1099</a></div>
 <div><img src="https://cdn.discordapp.com/emojis/761419274945953842.webp?size=20&quality=lossless" alt="WeModApp"/>&nbsp;<b>Just below this line, you will find a written guide</b></div><br> 
 
 <table>
@@ -191,6 +195,23 @@ Also, it's important to be aware that certain games may require
 launching exclusively through WeMod in desktop mode to access its features.
 
 ****
+<h3><img src="https://cdn.discordapp.com/emojis/1113579886439833690.gif?size=20&quality=lossless" alt="Heart"/>&nbsp;The Config File</h3>
+
+The script uses a config file in wich you can set some settings (this is optional):  
+In the file `wemod.conf` you can add the following under "[Settings]"
+- Use SteamCompatDataPath=$SPATH to override you steam compat folder
+- Use VirtualEnvironment=$VPATH to set a custom path for the venv eg. wemod_venv
+- Use RepoUser=$GITHUB_USERNAME to set the github user,  
+  to get prefix downloads from eg. DaniAsh551
+- Use RepoName=$NAME_OF_REPO to set the github repo,  
+  to get prefix downloads from eg. wemod-launcher
+- WeModLog=$LOG_PATH to set the wemod log file path eg. wemod.log
+
+Keep in mind if you use this you don't want to use the environment variable equivalent
+eg. WEMOD_LOG=$LOG_PATH in front of the steam command,
+SteamCompatDataPath is exluded from this, sice it has to be set manually.
+****
+
 
 <h3><img src="https://cdn.discordapp.com/emojis/1113579886439833690.gif?size=20&quality=lossless" alt="Heart"/>&nbsp;Guide Info</h3>
 <div><img src="https://cdn.discordapp.com/emojis/1049837871772729354.gif?size=20&quality=lossless" alt="Alert"/>&nbsp;<b>This guide is designed to remain adaptable and open to improvements in the future.</b><br>

--- a/setup.py
+++ b/setup.py
@@ -136,8 +136,7 @@ def main():
         log("Failed to unpack WeMod.")
         sg.popup("Failed to unpack WeMod.", "Failed to unpack WeMod.")
         sys.exit(1)
-
-
+        
 
 def init():
   print("Ensuring Dependencies...")

--- a/wemod
+++ b/wemod
@@ -6,13 +6,24 @@ import sys
 import os
 import re
 import subprocess
-from util import cache, exit_with_message, get_dotnet48, popup_download, wine, winetricks, log, popup_execute, check_dependencies, pip, popup_options, deref
+from util import cache, exit_with_message, get_dotnet48, popup_download, wine, winetricks, log, popup_execute
+from util import check_dependencies, pip, popup_options, deref, load_conf_setting, save_conf_setting
 from setup import main
 
 # Define paths and constants
 SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
 WEMOD_BAT = "C:\\\\windows\\\\system32\\\\start.exe Z:" + "\\\\".join(SCRIPT_PATH.split("/")) + "\\\\wemod.bat"
-BASE_STEAM_COMPAT = os.getenv("STEAM_COMPAT_DATA_PATH")
+loacom = load_conf_setting("SteamCompatDataPath")
+if not loacom:
+  BASE_STEAM_COMPAT = os.getenv("STEAM_COMPAT_DATA_PATH")
+elif loacom:
+  if os.path.isabs(loacom):
+    BASE_STEAM_COMPAT = str(loacom)
+  else:
+    BASE_STEAM_COMPAT = os.path.abspath(os.path.join(SCRIPT_PATH, loacom))
+
+del loacom
+
 WINEPREFIX = os.path.join(BASE_STEAM_COMPAT, "pfx")
 STEAM_COMPAT_FOLDER = os.path.abspath(os.path.dirname(BASE_STEAM_COMPAT))
 WINETRICKS = os.path.join(SCRIPT_PATH, "winetricks")
@@ -302,14 +313,31 @@ def download_prefix(proton_dir: str) -> None:
   # Check and prepare for first launch
   if not os.path.exists(WINEPREFIX + "/drive_c"):
     log(WINEPREFIX)
-    exit_with_message("First Launch","First Launch Detected: Please run the game once without wemod first.")
+    exit_with_message("First Launch","First Launch Detected: Please run the game once without wemod first. Error.")
 
-  repo_name = "DaniAsh551/wemod-launcher"
+
+  repo_user = load_conf_setting("RepoUser")
+  repo_name = load_conf_setting("RepoName")
+  if not repo_name:
+    repo_name = "DaniAsh551"
+    save_conf_setting("RepoUser",repo_name)
+  if not repo_user:
+    repo_user = "wemod-launcher"
+    save_conf_setting("RepoName",repo_user)
+
+  repo_parts = os.getenv(REPO_STRING).split("/",2)
+  if repo_parts[0] and repo_parts[0] != "":
+    repo_user = repo_parts[0]
+  if repo_parts[1] and repo_parts[1] != "":
+    repo_name = repo_parts[1]
+
+  repo_concat = repo_user + "/" + repo_name
+
 
   current_proton_version = read_version(os.path.join(BASE_STEAM_COMPAT, "version"))
   current_version_parts = parse_version(current_proton_version)
 
-  releases = get_github_releases(repo_name)
+  releases = get_github_releases(repo_concat)
   closest_version, url = find_closest_compatible_release(releases,current_version_parts)
   file_name = f"wemod_prefix{current_version_parts[0]}.{current_version_parts[1]}.zip"
 
@@ -320,8 +348,8 @@ def download_prefix(proton_dir: str) -> None:
   elif closest_version and current_version_parts:
     response = sg.popup_yes_no(f"The current version {closest_version[0]}.{closest_version[1]} might not be compatible with version {current_version_parts[0]}.{current_version_parts[1]}, download and use it?", title="Mabye copatible version found")
   else:
-    log("there was no version to download error")
-    sys.exit(0)
+    log(f"There was no version to download on repo '{repo_concat}', Error...")
+    exit_with_message("No downloads available",f"Nothing to download on repo '{repo_concat}'. Error.")
   if response == "No":
     log(f"User was unhappy with the version download choice of {closest_version[0]}.{closest_version[1]} for {current_version_parts[0]}.{current_version_parts[1]}, exiting")
     sys.exit(0)
@@ -367,7 +395,9 @@ def build_prefix(proton_dir: str) -> None:
 
   # Choose method to install dotnet48
   dotnet48_method = popup_options("dotnet48",
-    "Would you like to install dotnet48 with winetricks (default) or with wemod-launcher?",
+    """Would you like to install dotnet48 with winetricks (default) or with wemod-launcher?
+winetricks is for GE-Proton 8 or above and wemod-launcher is for GE-Proton 7
+be warned that GE-Proton 7 (the wemod-launcher opion) isn't working well, you can try using it anyway""",
     [ "winetricks", "wemod-launcher" ]
   )
 
@@ -456,51 +486,76 @@ def run(skip_init=False):
 
 # Log Python version and ensure dependencies
 requirements_txt = os.path.join(SCRIPT_PATH, "requirements.txt")
+
+save_conf_setting("ScriptName","wemod-laucher")
+save_conf_setting("Version","1.001")
+
 if check_dependencies(requirements_txt):
   log("All dependencies are already installed.")
 else:
-  log("Dependencies missing, creating virtual environment...")
+  log("Dependencies missing")
 
-  # Create a virtual environment using venv
-  venv_path = os.path.join(SCRIPT_PATH, "wemod_venv")
-  try:
-    subprocess.run([sys.executable, '-m', 'venv', venv_path], check=True)
-    log("Virtual environment created successfully.")
-  except subprocess.CalledProcessError:
-    log("Failed to create virtual environment, trying to force install venv")
-    return_code = pip("install --break-system-packages venv")
-    if return_code != 0:
-      log("CRITICAL: The python package 'venv' is not installed and could not be downloaded")
-      sys.exit(1)
-    else:
-      try:
-        subprocess.run([sys.executable, '-m', 'venv', venv_path], check=True)
-        log("Virtual environment created successfully.")
-      except subprocess.CalledProcessError:
-        log("Backup failed to create virtual environment, exiting")
-        sys.exit(1)
+  log("Trying to install Dependencies...")
 
-  # Determine the path to the Python executable within the virtual environment
-  venv_python = os.path.join(venv_path, 'bin', 'python')
-
-  # Build the command to re-run the script within the virtual environment
-  script_file = os.path.abspath(__file__)  # Assuming the current script is being run
-  command = [venv_python, script_file] + sys.argv[1:]  # Pass command line arguments
-
+  venv_path = load_conf_setting("VirtualEnvironment")
   # Try to install the dependencies
   pip_install = f"install -r '{requirements_txt}'"
-  return_code = pip(pip_install)
+  if not venv_path:
+    return_code = pip(pip_install)
+  else:
+    return_code = 98
   if return_code != 0:
+    if return_code != 98:
+      log("Creating virtual environment...")
+    else:
+      log("Ensuring virtual environment...")
+    # Create a virtual environment using venv
+    if not venv_path:
+      venv_path = "wemod_venv"
+    try:
+      if os.path.isabs(venv_path):
+        subprocess.run([sys.executable, '-m', 'venv', venv_path], check=True)
+      else:
+        subprocess.run([sys.executable, '-m', 'venv', os.path.abspath(os.path.join(SCRIPT_PATH, venv_path))], check=True)
+      log("Virtual environment created successfully.")
+    except subprocess.CalledProcessError:
+      log("Failed to create virtual environment, trying to force install venv")
+      return_code = pip("install --break-system-packages venv")
+      if return_code != 0:
+        log("CRITICAL: The python package 'venv' is not installed and could not be downloaded")
+        exit_with_message("Missing python-venv","The python package 'venv' is not installed and could not be downloaded. Error.")
+      else:
+        try:
+          if os.path.isabs(venv_path):
+            subprocess.run([sys.executable, '-m', 'venv', venv_path], check=True)
+          else:
+            subprocess.run([sys.executable, '-m', 'venv', os.path.abspath(os.path.join(SCRIPT_PATH, venv_path))], check=True)
+          log("Virtual environment created successfully.")
+        except subprocess.CalledProcessError:
+          log("CRITICAL: Backup failed to create virtual environment, exiting")
+          exit_with_message("Error on package venv","Failed to create virtual environment. Error.")
+
+    save_conf_setting("VirtualEnvironment",venv_path)
+    if venv_path and not os.path.isabs(venv_path):
+        venv_path = os.path.abspath(os.path.join(SCRIPT_PATH, venv_path))
+
+    # Determine the path to the Python executable within the virtual environment
+    venv_python = os.path.join(venv_path, 'bin', 'python')
+
+    # Build the command to re-run the script within the virtual environment
+    script_file = os.path.abspath(__file__)  # Assuming the current script is being run
+    command = [venv_python, script_file] + sys.argv[1:]  # Pass command line arguments
+
     return_code = pip(pip_install,venv_path)
     if return_code != 0:
       log("CRITICAL: Dependencies can't be installed")
-      sys.exit(1)
+      exit_with_message("Dependencies install error","Failed to install dependencies. Error.")
 
     log("Re-running script within virtual environment")
     # Execute the script within the virtual environment
     process = subprocess.run(command, capture_output=True, text=True)
-    log(process.stdout)
-    log(process.stderr)
+    print(str(process.stdout))
+    print(str(process.stderr))
     sys.exit(process.returncode)
 
 

--- a/wemod.bat
+++ b/wemod.bat
@@ -25,12 +25,12 @@ start "" %wemodpath%
 
 :wemod
 set wemodPID=
-for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist /FI "IMAGENAME eq %wemodname%"') do set wemodPID=%%b
+for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist /FI "IMAGENAME eq %wemodname%" 2>NUL') do set wemodPID=%%b
 if not errorlevel 0 (
     goto wemod
 )
 if not defined wemodPID (
-    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist /FI "IMAGENAME eq %wemodname%"') do set wemodPID=%%b
+    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist /FI "IMAGENAME eq %wemodname%" 2>NUL') do set wemodPID=%%b
 )
 
 
@@ -48,28 +48,28 @@ REM Couter to check if the game was detected correctly
 set /A counter=0
 
 :game
-for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "IMAGENAME eq %~n1%~x1" /NH') do set commandPID=%%b
+for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "IMAGENAME eq %~n1%~x1" /NH 2>NUL') do set commandPID=%%b
 if not errorlevel 0 (
     goto game
 )
 if not defined commandPID (
-    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "IMAGENAME eq %~n1%~x1" /NH') do set commandPID=%%b
+    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "IMAGENAME eq %~n1%~x1" /NH 2>NUL') do set commandPID=%%b
 )
 :loop
 set runningPID=
-for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH') do set runningPID=%%b
+for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH 2>NUL') do set runningPID=%%b
 if not errorlevel 0 (
     goto loop
 )
 if not defined runningPID (
-    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH') do set runningPID=%%b
+    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH 2>NUL') do set runningPID=%%b
     if not errorlevel 0 (
         goto loop
     )
 )
 
 if defined runningPID (
-    @ping localhost -n 1 > NUL
+    @ping localhost -n 1 > NUL 2>&1
     if %counter% LSS 50 (
         set /A counter=%counter%+1
     )
@@ -84,11 +84,11 @@ if defined wemodPID (
         pause
         echo.
     )
-    C:/windows/system32/taskkill.exe /PID %wemodPID% /F
-    C:/windows/system32/taskkill.exe /PID %wemodPID% /F
+    C:/windows/system32/taskkill.exe /PID %wemodPID% /F 2>NUL
+    C:/windows/system32/taskkill.exe /PID %wemodPID% /F 2>NUL
 )
 echo.
 echo Killed %wemodname% over pid %wemodPID%
 echo.
 echo Done, closing in 5 seconds
-@ping localhost -n 5 > NUL
+@ping localhost -n 5 > NUL 2>&1

--- a/wemod.bat
+++ b/wemod.bat
@@ -57,18 +57,18 @@ if not defined commandPID (
 )
 :loop
 set runningPID=
-for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH 2>NUL') do set runningPID=%%b
+for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH') do set runningPID=%%b
 if not errorlevel 0 (
     goto loop
 )
 if not defined runningPID (
-    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH 2>NUL') do set runningPID=%%b
+    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH') do set runningPID=%%b
     if not errorlevel 0 (
         goto loop
     )
 )
 if not defined runningPID (
-    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH 2>NUL') do set runningPID=%%b
+    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH') do set runningPID=%%b
     if not errorlevel 0 (
         goto loop
     )

--- a/wemod.bat
+++ b/wemod.bat
@@ -67,6 +67,12 @@ if not defined runningPID (
         goto loop
     )
 )
+if not defined runningPID (
+    for /F "TOKENS=1,2,*" %%a in ('C:/windows/system32/tasklist.exe /FI "PID eq %commandPID%" /NH 2>NUL') do set runningPID=%%b
+    if not errorlevel 0 (
+        goto loop
+    )
+)
 
 if defined runningPID (
     @ping localhost -n 1 > NUL 2>&1


### PR DESCRIPTION
There are lost of changes in this update:
I Split the ultil import
Added a config file
Relative paths to the script are now supported in the config:
- This file supports SteamCompatDataPath=$PATH where $PATH is your compat path
- It also suports VirtualEnvironment=$Path where $PATH is your venv path eg. wemod-venv
- For downloading supported is RepoUser=$GITHUB_USERNAME eg. DaniAsh551  
  and connected to that is RepoName=$NAME_OF_REPO eg. wemod-launcher
- Lastly in the config WeModLog=$PATH_TO_LOG eg. wemod.log
On all of these except SteamCompatDataPath the environment var has priority.
It will save a script name as well as a version in the config.

Other edits are
Renamed environment varible from REPO_NAME to REPO_STRING  
This is set like in the past eg. REPO_STRING=DaniAsh551/wemod-launcher  
Include in the dotnet48 build question message that proton 7 is old and might not work  
Moved virtual environment creation  
Add check for running in non virtual environment  
Added some error GUI boxes  
Script only prints self venv rerun, it doesn't need to log  
In the bat I added some sends error to null where possible  