### PR TITLE
Make the run function more steamline

### DIFF
--- a/wemod
+++ b/wemod
@@ -4,7 +4,6 @@ import shutil
 import venv
 import sys
 import os
-import re
 import subprocess
 from util import cache, exit_with_message, get_dotnet48, popup_download, wine, winetricks, log, popup_execute
 from util import check_dependencies, pip, popup_options, deref, load_conf_setting, save_conf_setting
@@ -12,7 +11,7 @@ from setup import main
 
 # Define paths and constants
 SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
-WEMOD_BAT = "C:\\\\windows\\\\system32\\\\start.exe Z:" + "\\\\".join(SCRIPT_PATH.split("/")) + "\\\\wemod.bat"
+WEMOD_BAT = f"start 'Z:{"\\\\".join(SCRIPT_PATH+os.sep+"wemod.bat".split(os.sep))}"
 loacom = load_conf_setting("SteamCompatDataPath")
 if not loacom:
   BASE_STEAM_COMPAT = os.getenv("STEAM_COMPAT_DATA_PATH")
@@ -30,29 +29,35 @@ WINETRICKS = os.path.join(SCRIPT_PATH, "winetricks")
 INIT_FILE = os.path.join(WINEPREFIX, ".wemod_installer")
 
 def parse_version(version_str = None):
-  # Replace '-' with '.' and ',' with '.'
   if version_str and isinstance(version_str, str):
+    # Replace '-' with '.' and ',' with '.'
     dot_version = version_str.replace("-", ".").replace(",", ".")
-
-    # Remove the Everything except for numbers and dots
-    reduced_version = re.sub(r"[^\d.]", "", dot_version)
-
-    # Remove . from front and back
-    clean_version = reduced_version.strip(".")
-
-    if clean_version != "": #make shure there is some minor version number
-      clean_version += ".0"
-
-    # Split by '.' and limit to the first two components (major.minor)
-    parts = clean_version.split('.')
-    if len(parts) > 2:
-      parts = parts[:2]  # Keep only the first two parts
-
-    # Rejoin the parts and convert to a float
-    try:
-      return [int(parts[0]),int(parts[1])]
-    except ValueError:
+    
+    # Clean up number
+    numbers = str(dot_version+".0")
+    majornumber = None
+    minornumber = None
+    addat = 0
+    currentnumber=""
+    for number in numbers:
+      if number and number.isnumeric():
+        currentnumber+=str(number)
+        if currentnumber:
+          if addat == 0:
+            majornumber = currentnumber
+          elif addat == 1:
+            minornumber = currentnumber
+      elif number and number=="." and currentnumber:
+        addat += 1
+        currentnumber=""
+      if addat > 1:
+        break
+    
+    if majornumber and minornumber: # Return numbers if set
+      return [int(majornumber), int(minornumber)]
+    else:
       return None
+    
   elif isinstance(version_str, list):
     return version_str
   return None
@@ -452,41 +457,78 @@ be warned that GE-Proton 7 (the wemod-launcher opion) isn't working well, you ca
   else:
     exit_with_message("ERROR", "Failed dependencies installation with code '{}'. Aborting...".format(resp), resp)
 
+def split_list_by_delimiter(input_list, delimiter):
+    result = []
+    current_sublist = []
+    for item in input_list:
+        if item == delimiter:
+            if current_sublist:
+                result.append(current_sublist)
+                current_sublist = []
+        else:
+            current_sublist.append(item)
+    if current_sublist:
+        result.append(current_sublist)
+    return result
+
+def join_lists_with_delimiter(sublists, delimiter=None):
+    result = []
+    for sublist in sublists:
+        result.extend(sublist)
+        if delimiter is not None:
+            result.append(delimiter)
+    if delimiter is not None and result:
+        result.pop() # Remove the last delimiter if delimiter is not None
+    return result
+
 # Main run function
 def run(skip_init=False):
-  ARGS= " ".join(sys.argv[1:])
-  AARGS=ARGS.split(" -- ")
-  REAPER_CMD=" -- ".join(AARGS[:-1])
-  PROTON_CMD=AARGS[-1].split(" ")
+  # Get passed args
+  ARGS= sys.argv[1:]
+
+  # Subdivide the list into multiple lists based on delimiter
+  AARGS = split_list_by_delimiter(ARGS,"--")
+
+  # Log the args for future improvment
+  log(f"The subsplit args list is {len(AARGS)} long and the full contents are: {AARGS}")
+
+  # Take the steam command part and merge it back into one list split by delimiter
+  REAPER_CMD = join_lists_with_delimiter(AARGS[:-1],"--")
+
+  # Take the end that runs the game
+  PROTON_CMD=AARGS[-1]
+
+  # Take the proton path
   PROTON=PROTON_CMD[0]
 
   # Initialize environment if not skipped
   if not skip_init:
     init(PROTON)
 
-  # Parse command to be executed
-  COMMAND=" ".join(PROTON_CMD[2:])
-  WIN_CMD=COMMAND.split(" ")[0].split("/")[-1] + " " + " ".join(COMMAND.split(" ")[1:])
-  WIN_PATHS=WIN_CMD.split("/")
-  DIR_CONTS = os.listdir(".")
+  # Get working dir
+  WORK_DIR=os.path.realpath(os.getcwd())
 
-  CORRECT_PATH = list(filter(lambda x: x in DIR_CONTS, WIN_PATHS))
+  # Get game exe
+  GAME_EXE=os.path.realpath(PROTON_CMD[2])
 
-  if len(CORRECT_PATH) > 0:
-    WIN_CMD = WIN_CMD[WIN_CMD.index(CORRECT_PATH[0]):]
+  # Make gamepath be relative to workdir (workdir is the root game dir)
+  REL_EXE=os.path.relpath(GAME_EXE, WORK_DIR)
 
-  WIN_CMD_SPLIT = WIN_CMD.split(".exe")
-  WIN_CMD = WIN_CMD_SPLIT[0] + ".exe"
-  LAUNCH_OPTIONS=""
+  # Make shure the gamepath is in windows format
+  WIN_CMD=REL_EXE.replace(os.sep,"\\\\")
 
-  if len(WIN_CMD_SPLIT) > 1:
-    LAUNCH_OPTIONS = ".exe".join(WIN_CMD_SPLIT[1:])
+  # If we have more args we prepare them to be added at the end
+  if len(PROTON_CMD) > 3:
+    LAUNCH_OPTIONS = " '" + "' '".join(PROTON_CMD[3:]) + "'"
+  else:
+    LAUNCH_OPTIONS = ""
 
-  SPLIT_WEMOD_BAT = WEMOD_BAT.split(" ")
-  QUOTED_WEMOD_BAT = f'\'{SPLIT_WEMOD_BAT[0]}\' \'{" ".join(SPLIT_WEMOD_BAT[1:])}\''
+  # Construct the final command
+  FINAL = f'\'{"' '".join(REAPER_CMD)}\' -- \'{PROTON}\' waitforexitandrun {WEMOD_BAT} \'{WIN_CMD}\'{LAUNCH_OPTIONS}'
 
-  FINAL = f'{REAPER_CMD} -- {PROTON} waitforexitandrun {QUOTED_WEMOD_BAT} \'{WIN_CMD}\'{LAUNCH_OPTIONS}'
+  # Log the final command
   log(f"Executing:\n\t{FINAL}\n")
+  print(f"Executing:\n\t{FINAL}\n")
 
   # Execute the final command
   process = subprocess.Popen(FINAL, stdout=subprocess.PIPE, shell=True)
@@ -504,7 +546,7 @@ requirements_txt = os.path.join(SCRIPT_PATH, "requirements.txt")
 
 script_name = "wemod-laucher"
 save_conf_setting("ScriptName",script_name)
-script_version = "1.001"
+script_version = "1.002"
 save_conf_setting("Version",script_version)
 log(f"The script {script_name} is running on version {script_version}")
 


### PR DESCRIPTION
The run function was a giant mess, so when [issue 61](https://github.com/DaniAsh551/wemod-launcher/issues/61) came up,  
I reworked the entire function.  
Now the function uses the arg list instead of converting to sting and list all the time.  
Also the version sting was also set to the new value 1.002.  
I have changed bat command to be easier to read  
and changed parse_version to no longer use re