### PR TITLE
fix(CI): Run Black formatter only on Python changes

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -4,10 +4,12 @@ on:
     branches:
       - main
       - dev
+    paths: ["*.py", "wemod"]
   pull_request:
     branches:
       - main
       - dev
+    paths: ["*.py", "wemod"]
 
 jobs:
   lint-and-format:


### PR DESCRIPTION
This makes the CI more efficient, and only runs the Python `black` formatter when there's a change to any filename matching the regex `*.py`, on branches: [main, dev].