### PR TITLE
fix: Make SCOOP_METADATA_URL deserialize to json

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -114,13 +114,10 @@ def download_wemod(temp_dir: str) -> str:
 
 def get_wemod_exe_url():
     import requests
-
-    SCOOP_METADATA_URL = (
-        "https://raw.githubusercontent.com/"
-        "Calinou/scoop-games/refs/heads/master/bucket/"
-        "wemod.json"
-    )
-    raw = requests.get(SCOOP_METADATA_URL).content
+    SCOOP_METADATA_URL = ("https://raw.githubusercontent.com/"
+                          "Calinou/scoop-games/refs/heads/master/bucket/"
+                          "wemod.json")
+    raw = requests.get(SCOOP_METADATA_URL).json()
 
     if not raw["architecture"]["64bit"]["url"]:
         exit_with_message(


### PR DESCRIPTION
Before we were trying to access dictionary keys that were of a byte
array type. This now uses the native Requests `.json()` method to
convert to a dictionary.