### PR TITLE
Restore url detection

### DIFF
--- a/src/wemod.py
+++ b/src/wemod.py
@@ -340,7 +340,6 @@ def syncwemod(
     action_needed = True
     # Handle the state of WeModExternal (the prefix-specific path)
     if os.path.islink(WeModExternal):
-        print("Checking link ---")
         # WeModExternal is a symlink. Check if it's correct.
         current_target = os.path.realpath(WeModExternal)
         if current_target == WeModData:


### PR DESCRIPTION
For some reason, the commit in #170 was swallowed into the ether, so I’m adding back URL‑protocol detection.

Can be merged after testing.