### PR TITLE
fix: create dosdevices dir after prefix copy

### DIFF
--- a/src/mainutils.py
+++ b/src/mainutils.py
@@ -383,7 +383,6 @@ def copy_folder_with_progress(
         ignore.remove(None)
         ignore = list(ignore) + [
             "pfx/drive_c/users",
-            "pfx/dosdevices",
             "pfx/drive_c/Program Files (x86)",
             "pfx/drive_c/Program Files",
             "pfx/drive_c/ProgramData",

--- a/src/wemod.py
+++ b/src/wemod.py
@@ -560,6 +560,17 @@ def init(proton: str, iswine: bool = False) -> None:
                 [None],
                 [None],
             )
+            # Ensure dosdevices exists and `drive_c`/`drive_z` are correctly symlinked.
+            dosdevices = os.path.join(WINEPREFIX, "dosdevices")
+            if not os.path.isdir(dosdevices):
+                os.makedirs(dosdevices)
+                c_drive = os.path.join(dosdevices, "c:")
+                z_drive = os.path.join(dosdevices, "z:")
+                if not os.path.exists(c_drive):
+                    os.symlink("../drive_c", c_drive)
+                if not os.path.exists(z_drive):
+                    os.symlink("/", z_drive)
+
             syncwemod()  # Sync WeMod data
             log(
                 f"Copied Proton version {cut_version[0]}.{cut_version[1]} prefix to game prefix that was on version {current_version_parts[0]}.{current_version_parts[1]}"


### PR DESCRIPTION
## Problem

`copy_folder_with_progress` in `mainutils.py` has `pfx/dosdevices` in its ignore list (line 386). When a compatible prefix gets copied to a new game's compatdata, the destination ends up without a `dosdevices/` directory. Proton then crashes during `setup_prefix()` trying to symlink into a directory that isn't there:

```
Proton: Prefix has an invalid version?! You may want to back up user files and delete this prefix.
Traceback (most recent call last):
  File ".../Proton - Experimental/proton", line 2103, in <module>
    g_session.init_session(sys.argv[1] != "runinprefix")
  File ".../Proton - Experimental/proton", line 1982, in init_session
    g_compatdata.setup_prefix()
  File ".../Proton - Experimental/proton", line 962, in setup_prefix
    os.symlink("../drive_c", self.prefix_dir + "/dosdevices/c:")
FileNotFoundError: [Errno 2] No such file or directory: '../drive_c' -> '.../pfx//dosdevices/c:'
```

The game never starts. You just get the troubleshooter popup every launch.

## Fix

After `copy_folder_with_progress` finishes in `wemod.py`, create `dosdevices/` with the standard symlinks (`c:` -> `../drive_c`, `z:` -> `/`) if it's missing. The ignore list entry is probably intentional to avoid copying stale symlinks between prefixes, so creating them fresh after the copy makes more sense than removing the ignore entry.

## Environment

- Arch Linux (KDE Plasma / Wayland)
- Proton Experimental (10.0 / 10.1000-200)
- wemod-launcher main branch (v1.539, commit 6c3355b)